### PR TITLE
README: Fix character encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # libconnect
 
-Diese Extension ist von Avonis im Auftrag der Staats- und Universitaetsbibliothek Hamburg entwickelt worden. Mit ihr lassen sich Ergebnisse aus den Informationssystemen EZB und DBIS der Universitaet Regensburg direkt in das TYPO3-System einbinden.  
+Diese Extension ist von Avonis im Auftrag der Staats- und Universitätsbibliothek Hamburg entwickelt worden.
+Mit ihr lassen sich Ergebnisse aus den Informationssystemen EZB und DBIS der Universität Regensburg direkt in das TYPO3-System einbinden.
 
-Ausf�hrliche Hinweise zur Konfiguration sind dem [Manual](doc/manual.pdf "Ausf�hrliches Manual") zu entnehmen.
+Ausführliche Hinweise zur Konfiguration sind dem [Manual](doc/manual.pdf "Ausführliches Manual") zu entnehmen.
 


### PR DESCRIPTION
Switch from ISO-8859 to UTF-8 encoding (which is the standard for
nearly all Open Source projects).

Replace also "Universitaetsbibliothek" by "Universitätsbibliothek"
which looks nicer.

Signed-off-by: Stefan Weil <sw@weilnetz.de>