### PR TITLE
Composer compatibility

### DIFF
--- a/Classes/Domain/Repository/DbisRepository.php
+++ b/Classes/Domain/Repository/DbisRepository.php
@@ -35,7 +35,9 @@ namespace Sub\Libconnect\Domain\Repository;
  *
  */
 
-require_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('libconnect') . 'Resources/Private/Lib/Dbis.php');
+if (!defined('TYPO3_COMPOSER_MODE') && defined('TYPO3_MODE')) {
+	require_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('libconnect') . 'Resources/Private/Lib/Dbis.php');
+}
 
 Class DbisRepository extends \TYPO3\CMS\Extbase\Persistence\Repository {
     private $dbis_to_t3_subjects = array();

--- a/Classes/Domain/Repository/EzbRepository.php
+++ b/Classes/Domain/Repository/EzbRepository.php
@@ -34,8 +34,10 @@ namespace Sub\Libconnect\Domain\Repository;
  * @license http://www.gnu.org/licenses/lgpl.html GNU Lesser General Public License, version 3 or later
  *
  */
-require_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('libconnect') . 'Resources/Private/Lib/Ezb.php');
-require_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('libconnect') . 'Resources/Private/Lib/Zdb.php');
+if (!defined('TYPO3_COMPOSER_MODE') && defined('TYPO3_MODE')) {
+	require_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('libconnect') . 'Resources/Private/Lib/Ezb.php');
+	require_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('libconnect') . 'Resources/Private/Lib/Zdb.php');
+}
 
 Class EzbRepository extends \TYPO3\CMS\Extbase\Persistence\Repository {
     private $ezb_to_t3_subjects = array();

--- a/Resources/Private/Lib/Dbis.php
+++ b/Resources/Private/Lib/Dbis.php
@@ -37,8 +37,10 @@
  *
  */
 
-require_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('libconnect') . 'Resources/Private/Lib/Xmlpageconnection.php');
-require_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('libconnect') . 'Resources/Private/Lib/Httppageconnection.php');
+if (!defined('TYPO3_COMPOSER_MODE') && defined('TYPO3_MODE')) {
+	require_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('libconnect') . 'Resources/Private/Lib/Xmlpageconnection.php');
+	require_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('libconnect') . 'Resources/Private/Lib/Httppageconnection.php');
+}
 
 class Tx_Libconnect_Resources_Private_Lib_Dbis {
 

--- a/Resources/Private/Lib/Ezb.php
+++ b/Resources/Private/Lib/Ezb.php
@@ -39,8 +39,10 @@
  *
  */
 
-require_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('libconnect') . 'Resources/Private/Lib/Xmlpageconnection.php');
-require_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('libconnect') . 'Resources/Private/Lib/Httppageconnection.php');
+if (!defined('TYPO3_COMPOSER_MODE') && defined('TYPO3_MODE')) {
+	require_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('libconnect') . 'Resources/Private/Lib/Xmlpageconnection.php');
+	require_once(\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('libconnect') . 'Resources/Private/Lib/Httppageconnection.php');
+}
 
 class Tx_libconnect_Resources_Private_Lib_Ezb {
 

--- a/composer.json
+++ b/composer.json
@@ -9,17 +9,23 @@
         "issues": "https://forge.typo3.org/projects/libconnect"
     },
     "require": {
-        "typo3/cms-core": "^6.0.0 || ^7.6.0"
+        "typo3/cms-core": "^6.0.0 || ^7.6.0 || ^8.7.0"
     },
     "autoload": {
         "psr-4": {
             "Sub\\Libconnect\\": "Classes/"
         },
-        "psr-4": {
-            "Sub\\Libconnect\\": "Resources/Private/Lib/"
-        },
-        "psr-4": {
-            "Sub\\Libconnect\\": "Classes/UserFunctions/"
-        }
+        "files": [
+            "Resources/Private/Lib/Dbis.php",
+            "Resources/Private/Lib/Ezb.php",
+            "Resources/Private/Lib/Zdb.php",
+            "Resources/Private/Lib/Xmlpageconnection.php",
+            "Resources/Private/Lib/Httppageconnection.php"
+        ]
+    },
+    "replace": {
+        "libconnect": "self.version",
+        "typo3-ter/libconnect": "self.version",
+        "Sub/libconnect": "self.version"
     }
 }


### PR DESCRIPTION
This PR contains lowlevel changes to ensure functionality in composer environments.
Any further changes included.

Tested with TYPO3 8.7.8 (only).