### PR TITLE
Fix some typos and improve text in README.md

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -55,7 +55,7 @@
     - Fixed WizIcon for TYPO3 8
 5.4.0
     - Fixed missed Wizicons
-    - Changed view pathes in TS
+    - Changed view paths in TS
     - End of support of TYPO3 6
     - show overview on empty search
     

--- a/Classes/Controller/DbisController.php
+++ b/Classes/Controller/DbisController.php
@@ -59,7 +59,7 @@ class DbisController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController 
     }
 
     /**
-     * shows a list of databases (for general, search, choosed subject)
+     * shows a list of databases (for general, search, chosen subject)
      */
     public function displayListAction() {
         $params = array();
@@ -84,7 +84,7 @@ class DbisController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController 
             }
         }
 
-        if (!empty($params['subject'])) {//choosed subject after start point
+        if (!empty($params['subject'])) {//chosen subject after start point
             $config['sort'] = $this->settings['flexform']['sortParameter'];
             $config['detailPid'] = $this->settings['flexform']['detailPid'];
 

--- a/Classes/Controller/EzbController.php
+++ b/Classes/Controller/EzbController.php
@@ -63,7 +63,7 @@ class EzbController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController  
     }
 
      /**
-     * shows a list of journals (for general, search, choosed subject)
+     * shows a list of journals (for general, search, chosen subject)
      */
     public function displayListAction() {
         $params = array();
@@ -88,7 +88,7 @@ class EzbController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController  
         $Pid = intval($GLOBALS['TSFE']->id);
         $this->view->assign('pageUid', $Pid);
 
-        if ((!empty($params['subject'])) || (!empty($params['notation']))) {//choosed subject after start point
+        if ((!empty($params['subject'])) || (!empty($params['notation']))) {//chosen subject after start point
 
             $config['detailPid'] = $this->settings['flexform']['detailPid'];
             
@@ -271,7 +271,7 @@ class EzbController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController  
 
         //if new activated should here the new for subject be active
         if(!empty($this->settings['flexform']['newPid'])){
-            //if subject is choosed link  to subject list is displayed
+            //if subject is chosen link to subject list is displayed
             if ( !empty($params['subject']) ) {
                 $this->view->assign('showSubjectLink', true);
 
@@ -450,13 +450,13 @@ class EzbController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController  
 
         $config['partnerPid'] = 0;
         $journal =  $this->ezbRepository->loadDetail($params['jourid'], $config);
-        $titel = $journal['title'];
+        $title = $journal['title'];
         unset($journal);
 
         //variables for template
         $this->view->assign('ParticipantsList', $ParticipantsList);
         $this->view->assign('jourid', $params['jourid']);
-        $this->view->assign('titel', $titel);
+        $this->view->assign('titel', $title);
     }
 
     /**

--- a/Classes/Domain/Repository/DbisRepository.php
+++ b/Classes/Domain/Repository/DbisRepository.php
@@ -100,7 +100,7 @@ Class DbisRepository extends \TYPO3\CMS\Extbase\Persistence\Repository {
             $result = $dbis->getDbliste($dbis_id, $config['sort'], $accessFilter);
         }else{//for own collection or all subject
             
-            //access sort for all entrys in all subjects is not possible
+            //access sort for all entries in all subjects is not possible
             if($config['sort'] == 'access'){
                 $config['sort'] = 'alph';
             }

--- a/Classes/Domain/Repository/EzbRepository.php
+++ b/Classes/Domain/Repository/EzbRepository.php
@@ -486,7 +486,7 @@ Class EzbRepository extends \TYPO3\CMS\Extbase\Persistence\Repository {
 //EOF ZDB LocationData
 
     /**
-     * set detailed access informations
+     * set detailed access information
      * 
      * @param array $longAccessInfos
      */
@@ -495,7 +495,7 @@ Class EzbRepository extends \TYPO3\CMS\Extbase\Persistence\Repository {
     }
     
     /**
-     * get detailed access informations
+     * get detailed access information
      * 
      * @return array
      */
@@ -544,7 +544,7 @@ Class EzbRepository extends \TYPO3\CMS\Extbase\Persistence\Repository {
                     }
                 }
             }else{
-                //if licence informations are missing
+                //if licence information is missing
                 foreach($colortext['longAccessInfos'] as $key => $text){
                     if(empty($AccessInfos[$key])){
                         $AccessInfos[$key] = $colortext['longAccessInfos'][$key];

--- a/Classes/ViewHelpers/TrimedstrlenNpViewHelper.php
+++ b/Classes/ViewHelpers/TrimedstrlenNpViewHelper.php
@@ -21,7 +21,7 @@ class TrimedstrlenNpViewHelper extends AbstractViewHelper {
     }
 
     /**
-     * Returns trimed string
+     * Returns trimmed string
      * 
      * @param array $arguments
      * @param \Closure $renderChildrenClosure

--- a/Classes/ViewHelpers/TrimedstrlenViewHelper.php
+++ b/Classes/ViewHelpers/TrimedstrlenViewHelper.php
@@ -12,7 +12,7 @@ namespace Sub\Libconnect\ViewHelpers;
 class TrimedstrlenViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper {
 
     /**
-     * Returns trimed string
+     * Returns trimmed string
      *
      * @param string $string
      * @return string

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # libconnect
 
-Libconnect is an TYPO3 extension which was inital developed by Avonis for the Staats- und Universitätsbibliothek Hamburg Carl von Ossietzky (SUB). The SUB develop the continuously.
-With libconnect it´s possible to display the information of EZB and DBIS of the University Regensburg on an TYPO3 based website.
+Libconnect is an TYPO3 extension which was initially developed by Avonis for the Staats- und Universitätsbibliothek Hamburg Carl von Ossietzky (SUB).
+The SUB maintains it now.
+With libconnect it is possible to display the information of EZB and DBIS of the University Regensburg on an TYPO3 based website.
 
-Here is the german [Manual](doc/manual.pdf "Ausführliches Manual").
+Here is the German [Manual](doc/manual.pdf "Ausführliches Manual").
 
 Visit our git repository: https://github.com/subhh/libconnect
 


### PR DESCRIPTION
Most typos were found by codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>