### PR TITLE
fix mismatching function name in SubjectRepository

### DIFF
--- a/Classes/Domain/Repository/SubjectRepository.php
+++ b/Classes/Domain/Repository/SubjectRepository.php
@@ -39,7 +39,7 @@ Class SubjectRepository extends \TYPO3\CMS\Extbase\Persistence\Repository {
      * 
      * @return object
      */
-    public function myFindAll() {
+    public function findAll() {
         $query = $this->createQuery();
         $query->statement('SELECT * FROM tx_libconnect_domain_model_subject WHERE deleted = 0 AND hidden = 0');
 


### PR DESCRIPTION
After installation the list by subject is not working (subject ID is missing in the URL). This seems to be caused by a mismatching function name.
Function is declared as `myFindAll()` in `SubjectRepository.php` but called with `findAll()` from `DbisRepository.php` and `EzbRepository.php`.