### PR TITLE
Fix some typos in documentation, comments and messages

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,7 +24,7 @@
 9.0.3
     - EZB: 
         - Reduces amount of requests to API.
-        - Fixed wrong doamin of ezb
+        - Fixed wrong domain of ezb
 9.0.2
     - EZB:
        - Fixed error: no search results, if someone uses in extended search only jq_term2 or higher. Http_built_query removed elements with null values and the API do not accept the other parameters.
@@ -43,7 +43,7 @@
     - Fixed broken code
 8.1.0
     - EZB: plug-in use now only the xml interface and not the database
-    - Fixed unsecure url schemes
+    - Fixed insecure url schemes
     - using of standard view helper
         - Removed StrlenNp helper function
         - removed compare view helper
@@ -54,7 +54,7 @@
     - EZB- Details:
         - Title history.
             - ZDBID and period now in same underlined line like original EZB view.
-            - Fixed sorting of precursor vom oldes to newest.
+            - Fixed sorting of precursor from oldest to newest.
             - Fixed incomplete list
         - added open access policy search link to SHERPA/RoMEO
         - fixed keywords
@@ -108,9 +108,9 @@
     - DBIS: 
         - list, new in DBIS: decide to show short or full licence information
         - fixed double access information in lists
-    - better comatibility to TYPO3 8 LTS
+    - better compatibility to TYPO3 8 LTS
 6.0.3
-    - Class decideIncludeCSS removed --> used deprecated funktions.
+    - Class decideIncludeCSS removed --> used deprecated functions.
     - Typoscript: ezbNoCSS and dbisNoCSS settings removed
     - DBIS: 
         - new in DBIS: Changed Text and date for better reading

--- a/Classes/Controller/DbisController.php
+++ b/Classes/Controller/DbisController.php
@@ -9,7 +9,7 @@ namespace Subhh\Libconnect\Controller;
 *
 * All rights reserved
 *
-* This script is part of the EZB/DBIS-Extention project. The EZB/DBIS-Extention project
+* This script is part of the EZB/DBIS-Extension project. The EZB/DBIS-Extension project
 * is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation; either version 2 of the License, or

--- a/Classes/Controller/EzbController.php
+++ b/Classes/Controller/EzbController.php
@@ -9,7 +9,7 @@ namespace Subhh\Libconnect\Controller;
 *
 * All rights reserved
 *
-* This script is part of the EZB/DBIS-Extention project. The EZB/DBIS-Extention project
+* This script is part of the EZB/DBIS-Extension project. The EZB/DBIS-Extension project
 * is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation; either version 2 of the License, or

--- a/Classes/Domain/Repository/DbisRepository.php
+++ b/Classes/Domain/Repository/DbisRepository.php
@@ -11,7 +11,7 @@ use Subhh\Libconnect\Lib\Dbis;
 *
 * All rights reserved
 *
-* This script is part of the EZB/DBIS-Extention project. The EZB/DBIS-Extention project
+* This script is part of the EZB/DBIS-Extension project. The EZB/DBIS-Extension project
 * is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation; either version 2 of the License, or

--- a/Classes/Domain/Repository/EzbRepository.php
+++ b/Classes/Domain/Repository/EzbRepository.php
@@ -9,7 +9,7 @@ namespace Subhh\Libconnect\Domain\Repository;
 *
 * All rights reserved
 *
-* This script is part of the EZB/DBIS-Extention project. The EZB/DBIS-Extention project
+* This script is part of the EZB/DBIS-Extension project. The EZB/DBIS-Extension project
 * is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation; either version 2 of the License, or
@@ -317,7 +317,7 @@ class EzbRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
         $journals['AccessInfos'] = $journals['selected_colors'];
         $journals['colors'] = $colors;
 
-        //create addtionals parameter for links
+        //create additional parameters for links
         $linkParams = [];
         foreach ($searchVars as $key => $value) {
             $linkParams['link']['libconnect'][$key] = $value;
@@ -547,7 +547,7 @@ class EzbRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
     {
         $list = [];
 
-        //search terms and theire categories
+        //search terms and their categories
         $jq = '';
 
         if (!empty($searchVars['sword'])) {
@@ -627,7 +627,7 @@ class EzbRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
     }
 
     /**
-     * returns a singel value for parameter colors.
+     * returns a single value for parameter colors.
      *
      * @param array $colors
      *

--- a/Classes/Lib/Dbis.php
+++ b/Classes/Lib/Dbis.php
@@ -9,7 +9,7 @@ namespace Subhh\Libconnect\Lib;
 *
 * All rights reserved
 *
-* This script is part of the EZB/DBIS-Extention project. The EZB/DBIS-Extention project
+* This script is part of the EZB/DBIS-Extension project. The EZB/DBIS-Extension project
 * is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation; either version 2 of the License, or
@@ -194,7 +194,7 @@ class Dbis
                 $params['lett'] = 'f';
                 $params['gebiete'] = $fachgebiet;
             } else {
-                //notation is a character => own colelction
+                //notation is a character => own collection
                 $params['lett'] = 'c';
                 $params['collid'] = $fachgebiet;
             }
@@ -442,7 +442,7 @@ class Dbis
                                 'href' => $href
                             ];
                         } else {
-                            //other links to start resarch
+                            //other links to start research
                             $details['access_lic'][$type][] = [
                                 'name' => (string)$access,
                                 'href' => $href
@@ -628,7 +628,7 @@ class Dbis
 
         if (isset($response->list_dbs->dbs)) {
 
-            //get numer of results
+            //get number of results
             if (isset($response->list_dbs->dbs->attributes()->db_count)) {
                 $list['db_count'] = (int)$response->list_dbs->dbs->attributes()->db_count;
             }

--- a/Classes/Lib/Ezb.php
+++ b/Classes/Lib/Ezb.php
@@ -9,7 +9,7 @@ namespace Subhh\Libconnect\Lib;
 *
 * All rights reserved
 *
-* This script is part of the EZB/DBIS-Extention project. The EZB/DBIS-Extention project
+* This script is part of the EZB/DBIS-Extension project. The EZB/DBIS-Extension project
 * is free software; you can redistribute it and/or modify
 * it under the terms of the GNU General Public License as published by
 * the Free Software Foundation; either version 2 of the License, or
@@ -339,7 +339,7 @@ class Ezb
                     $warpto = urlencode((string)$period->warpto_link->attributes()->url);
                 }
 
-                //check for uncomplete link
+                //check for incomplete link
                 $readme_link = (string)@$period->readme_link->attributes()->url;
 
                 if (!empty($readme_link)) {
@@ -382,7 +382,7 @@ class Ezb
     }
 
     /**
-     * creates search url, contains of the doamin and an array of parameter
+     * creates search url, contains of the domain and an array of parameter
      *
      * @param term string
      * @param searchVars array
@@ -437,10 +437,10 @@ class Ezb
     }
 
     /**
-     * Caclulate the sum of all colors
+     * Calculate the sum of all colors
      *
      * @param mixed $colors
-     * @return intger sum
+     * @return integer sum
      */
     private function getColorSum($colors)
     {
@@ -582,7 +582,7 @@ class Ezb
     }
 
     /**
-     * retruns access information
+     * returns access information
      *
      * @return array $return
      */

--- a/Classes/Lib/Zdb.php
+++ b/Classes/Lib/Zdb.php
@@ -197,7 +197,7 @@ class Zdb
             return false;
         }
 
-        //as the script is stil running the XML-Object contains all the data necessary for the location information, so continue
+        //as the script is still running the XML-Object contains all the data necessary for the location information, so continue
         /**
          * two branches: <ElectronicData> : electronic availability
          *               <PrintData> : print

--- a/Classes/ViewHelpers/TrimedstrlenNpViewHelper.php
+++ b/Classes/ViewHelpers/TrimedstrlenNpViewHelper.php
@@ -7,7 +7,7 @@ use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithRenderStatic;
 
 /**
- * This class is a view helper that count a trimed string.
+ * This class is a view helper that count a trimmed string.
  *
  * @version
  */

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -120,7 +120,7 @@ Default: empty
 ZDB: filter location information
 ================================
 
-Comma seperated list of integer. The values are location states which are dispayed.
+Comma separated list of integer. The values are location states which are displayed.
 
 2 = available, 3 = limited availability (moving wall, etc.), 4 = journal not available
 

--- a/Documentation/Editor/Index.rst
+++ b/Documentation/Editor/Index.rst
@@ -50,7 +50,7 @@ Detail page: Choose a detail page.
 List
 ----
 
-Generates a list of datbases and links to the detail page. It is also used for search results.
+Generates a list of databases and links to the detail page. It is also used for search results.
 
 Detail page: Choose a detail page.
 
@@ -88,7 +88,7 @@ Page with detailed search : set page with search.
 
  How How many days are entries marked as new? (default: 7): set the number of days for "New in dbis" how long entries marked as new.
 
-New in DBIS: set page with the "New in DBIS" output. Generates a link to "New in DBIS" with number of new entries. If you choose a subject in list, you get new entries for this subject too. If you donn´t want to use this feature, let it empty.
+New in DBIS: set page with the "New in DBIS" output. Generates a link to "New in DBIS" with number of new entries. If you choose a subject in list, you get new entries for this subject too. If you don´t want to use this feature, let it empty.
 
 .. figure:: ../Images/Editor/DbisBackendSidebar.png
    :width: 800px
@@ -107,13 +107,13 @@ List view: set page with dbis plug-in with output as list.
    :width: 800px
    :alt: output as sidebar
 
-   Configuring the seach form.
+   Configuring the search form.
 
 
 New Databases
 -------------
 
-It generats a list with all new databases. You decide how long is a database new.
+It generates a list with all new databases. You decide how long is a database new.
 
 Detail page: Choose a detail page.
 
@@ -185,7 +185,7 @@ This is a search bar to use on top or as sidebar.
 
  How How many days are entries marked as new? (default: 7): set the number of days for "New in ezb" how long entries marked as new.
 
-New in EZB: set page with the "Neu in EZB". Generates a link to "Neu in EZB" with number of new entries. If you choose a subject in list, you get new entries for this subject too. If you donn´t want to use this feature, let it empty.
+New in EZB: set page with the "Neu in EZB". Generates a link to "Neu in EZB" with number of new entries. If you choose a subject in list, you get new entries for this subject too. If you don´t want to use this feature, let it empty.
 
 .. figure:: ../Images/Editor/EzbBackendSidebar.png
    :width: 800px
@@ -204,12 +204,12 @@ List view: set page with dbis plug-in with output as list.
    :width: 800px
    :alt: output as sidebar
 
-   Configuring the seach form.
+   Configuring the search form.
 
 New Journals
 ------------
 
-It generats a list with all new journals. You decide how long is a journal new.
+It generates a list with all new journals. You decide how long is a journal new.
 
 Detail page: Choose a detail page.
 

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -16,7 +16,7 @@ Introduction
 What does it do?
 ================
 
-With libconnect it is possible to display the information of Electronic Journals Library (EZB) and the Database informations system (DBIS) of the University Regensburg on an TYPO3 based website.
+With libconnect it is possible to display the information of Electronic Journals Library (EZB) and the Database information system (DBIS) of the University Regensburg on an TYPO3 based website.
 
 The visitors stay on your website and you can use your own styles.
 

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -31,7 +31,7 @@
                     <target>Weitere freie Zugänge:</target>
                 </trans-unit>
                 <trans-unit id="tx_libconnect.dbis.detail.access.other" xml:space="preserve">
-                    <source>Addtion internet offer:</source>
+                    <source>Additional internet offer:</source>
                     <target>Zusätzliches Internet-Angebot:</target>
                 </trans-unit>
                 <trans-unit id="tx_libconnect.dbis.detail.access.ppu" xml:space="preserve">
@@ -309,7 +309,7 @@
                     <target>3. Wählen Sie die Einrichtung aus:</target>
                 </trans-unit>
                 <trans-unit id="tx_libconnect.ezb.articipants.submit" xml:space="preserve">
-                    <source>Go to the choosed institution</source>
+                    <source>Go to the chosen institution</source>
                     <target>Zur gewählten Einrichtung wechseln</target>
                 </trans-unit>
 

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -25,7 +25,7 @@
                     <source>More Free Access:</source>
                 </trans-unit>
                 <trans-unit id="tx_libconnect.dbis.detail.access.other" xml:space="preserve">
-                    <source>Addtion internet offer:</source>
+                    <source>Additional internet offer:</source>
                 </trans-unit>
                 <trans-unit id="tx_libconnect.dbis.detail.access.ppu" xml:space="preserve">
                     <source>More Pay-per-Use Access:</source>
@@ -237,7 +237,7 @@
                     <source>3. Choose your institution:</source>
                 </trans-unit>
                 <trans-unit id="tx_libconnect.ezb.articipants.submit" xml:space="preserve">
-                    <source>Go to the choosed institution</source>
+                    <source>Go to the chosen institution</source>
                 </trans-unit>
 
                 <trans-unit id="tx_libconnect.ezb.detail.appearence" xml:space="preserve">


### PR DESCRIPTION
The typos were found by `codespell` and `typos`.